### PR TITLE
perf(search): skip unindexed multi-column LIKE scan for <2-char terms

### DIFF
--- a/Filter/SearchFilter.php
+++ b/Filter/SearchFilter.php
@@ -63,6 +63,13 @@ final class SearchFilter extends AbstractFilter
             return;
         }
         $stringValue = self::mixedToString($value);
+        // Skip the unindexed multi-column LOWER(...) LIKE '%term%' scan (with auto
+        // leftJoins) for too-short terms: a single character matches almost every
+        // row across every searched field/join — the worst-case full scan. Search
+        // for terms of >= 2 characters is unchanged.
+        if (mb_strlen(trim($stringValue)) < 2) {
+            return;
+        }
         $this->logger->info('Search for: "'.$stringValue.'"');
         $annotation = self::readSearchAttribute($resourceClass);
         if (null === $annotation || [] === $annotation->fields) {


### PR DESCRIPTION
Short search terms (<2 chars) expanded to LOWER(col) LIKE '%x%' across every searched field + auto-leftJoins — a worst-case full scan. Bail out for <2-char terms; >=2 chars unchanged. PHPStan max [OK]; functional smoke green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)