### PR TITLE
feat(web_admin): top-level Administrace link + admin message skeleton

### DIFF
--- a/Resources/views/web/parts/main-menu.html.twig
+++ b/Resources/views/web/parts/main-menu.html.twig
@@ -4,4 +4,35 @@
             <span itemprop="name">{{ menuItem.title }}</span>
         </a>
     {% endfor %}
+    {% if is_granted('ROLE_ADMIN') %}
+        <a href="{{ path('oswis_org_oswis_core_web_admin_homepage') }}" itemprop="url"
+           class="website-main-menu-admin" title="Administrace">
+            <span itemprop="name">Administrace</span>
+        </a>
+    {% endif %}
 </nav>
+{# Active-item highlight: done client-side because this menu is ESI-rendered (the
+   fragment's app.request is not the page request), so the longest matching link
+   wins (e.g. /web_admin/... highlights "Administrace"). #}
+<style>
+    #website-main-menu a.is-active { font-weight: 700; box-shadow: inset 0 -2px 0 0 currentColor; }
+    #website-main-menu a.website-main-menu-admin { font-weight: 700; opacity: .85; }
+</style>
+<script>
+    (function () {
+        var nav = document.getElementById('website-main-menu');
+        if (!nav) { return; }
+        var strip = function (p) { return (p || '').replace(/\/+$/, '') || '/'; };
+        var here = strip(window.location.pathname);
+        var best = null, bestLen = -1;
+        nav.querySelectorAll('a[href]').forEach(function (a) {
+            var p;
+            try { p = strip(new URL(a.getAttribute('href'), window.location.origin).pathname); }
+            catch (e) { return; }
+            if (here === p || (p !== '/' && here.indexOf(p + '/') === 0)) {
+                if (p.length > bestLen) { best = a; bestLen = p.length; }
+            }
+        });
+        if (best) { best.classList.add('is-active'); best.setAttribute('aria-current', 'page'); }
+    })();
+</script>

--- a/Resources/views/web_admin/message.html.twig
+++ b/Resources/views/web_admin/message.html.twig
@@ -1,0 +1,22 @@
+{% extends '@OswisOrgOswisCore/web_admin/page-skeleton-web-admin.html.twig' %}
+
+{# Admin-side counterpart of web/pages/message.html.twig: same title/message interface,
+   but rendered inside the admin skeleton so completed/failed admin actions keep the
+   admin header + menu instead of dropping the user onto the public site. #}
+{% block body_content %}
+    <main id="message" class="container">
+        <div class="row">
+            <div class="col">
+                <header>
+                    <h2 class="text-uppercase">{{ title|default }}</h2>
+                </header>
+                <section>
+                    <p>{{ message|default }}</p>
+                </section>
+                {% if backUrl|default %}
+                    <p><a class="btn btn-outline-secondary btn-sm" href="{{ backUrl }}">← Zpět</a></p>
+                {% endif %}
+            </div>
+        </div>
+    </main>
+{% endblock body_content %}


### PR DESCRIPTION
Part of the unified participant-list work.

- **#A** Top-level **Administrace** link in the main menu for ROLE_ADMIN (with client-side active-item highlight) — admins reach `/web_admin` from anywhere.
- **#B** `web_admin/message.html.twig` admin-skeleton message page so admin actions (mail send, payment import) render inside the admin layout instead of bouncing to the public web.

Verification: PHPStan level max 0 errors; twig lint OK; functional AdminSmokeTest green against clone DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)