### PR TITLE
release: v0.2.15 — branded PDF export + web_admin flash rendering

### DIFF
--- a/Export/ExportManager.php
+++ b/Export/ExportManager.php
@@ -45,13 +45,18 @@ final class ExportManager
         $header = array_map(static fn (ExportColumn $c): string => $c->label, $columns);
 
         $rows = [];
+        $numericSums = []; // index sloupce => součet (jen NUMBER sloupce)
         foreach ($entities as $entity) {
             if (!is_object($entity)) {
                 continue;
             }
             $row = [];
-            foreach ($columns as $column) {
-                $row[] = $this->formatValue($column->extract($entity), $column->type);
+            foreach ($columns as $i => $column) {
+                $raw = $column->extract($entity);
+                if (ExportColumn::TYPE_NUMBER === $column->type && is_numeric($raw)) {
+                    $numericSums[$i] = ($numericSums[$i] ?? 0.0) + (float) $raw;
+                }
+                $row[] = $this->formatValue($raw, $column->type);
             }
             $rows[] = $row;
         }
@@ -60,10 +65,29 @@ final class ExportManager
         if ($request->format->isCsv()) {
             $content = $this->csvExportService->build($header, $rows, $request->format->toCsvFormat());
         } else {
+            // PDF: číselné sloupce vpravo + řádek součtů (jen číselné sloupce).
+            $align = array_map(
+                static fn (ExportColumn $c): string => ExportColumn::TYPE_NUMBER === $c->type ? 'right' : 'left',
+                $columns,
+            );
+            $hasTotals = [] !== $numericSums;
+            $totals = [];
+            if ($hasTotals) {
+                foreach (array_keys($columns) as $i) {
+                    $totals[$i] = array_key_exists($i, $numericSums)
+                        ? rtrim(rtrim(number_format($numericSums[$i], 2, ',', ' '), '0'), ',')
+                        : '';
+                }
+            }
             $html = $this->twig->render(self::PDF_TEMPLATE, [
-                'title'  => $definition->getTitle(),
-                'header' => $header,
-                'rows'   => $rows,
+                'title'     => $definition->getTitle(),
+                'subtitle'  => $request->subtitle,
+                'header'    => $header,
+                'rows'      => $rows,
+                'align'     => $align,
+                'totals'    => $totals,
+                'hasTotals' => $hasTotals,
+                'count'     => count($rows),
             ]);
             $content = $this->exportService->getPdfFromHtml($html, count($columns) >= self::PDF_LANDSCAPE_MIN);
         }

--- a/Export/ExportManager.php
+++ b/Export/ExportManager.php
@@ -89,7 +89,13 @@ final class ExportManager
                 'hasTotals' => $hasTotals,
                 'count'     => count($rows),
             ]);
-            $content = $this->exportService->getPdfFromHtml($html, count($columns) >= self::PDF_LANDSCAPE_MIN);
+            $content = $this->exportService->getPdfFromHtml(
+                $html,
+                count($columns) >= self::PDF_LANDSCAPE_MIN,
+                $definition->getTitle(),
+                $request->subtitle,
+                ['export', $definition->getKey()],
+            );
         }
 
         return new ExportResult($filename, $request->format->mimeType(), $content);

--- a/Export/ExportRequest.php
+++ b/Export/ExportRequest.php
@@ -10,10 +10,12 @@ final class ExportRequest
 {
     /**
      * @param list<string>|null $columnKeys vybrané sloupce v pořadí; null = výchozí sada
+     * @param string|null       $subtitle   scope do hlavičky PDF (akce/typ/počet); null = bez podtitulku
      */
     public function __construct(
         public readonly ExportFormat $format,
         public readonly ?array $columnKeys = null,
+        public readonly ?string $subtitle = null,
     ) {
     }
 }

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -182,6 +182,7 @@ services:
             - '@monolog.logger'
             - '@twig'
             - '@oswis_org_oswis_core.oswis_core_settings_provider'
+            - '%kernel.project_dir%'
     OswisOrg\OswisCoreBundle\Service\ExportService:
         alias: oswis_org_oswis_core.export_service
         public: true

--- a/Resources/views/export/table.pdf.html.twig
+++ b/Resources/views/export/table.pdf.html.twig
@@ -1,25 +1,38 @@
 <style>
-    body { font-family: sans-serif; font-size: 9pt; color: #222; }
-    h1 { font-size: 14pt; margin: 0 0 8px; }
+    body { font-family: sans-serif; font-size: 8.5pt; color: #222; }
+    .doc-head { border-bottom: 1.5px solid #006FAD; padding-bottom: 4px; margin-bottom: 8px; }
+    .doc-head h1 { font-size: 14pt; margin: 0; color: #006FAD; }
+    .doc-head .sub { font-size: 9pt; color: #555; margin-top: 2px; }
     table { width: 100%; border-collapse: collapse; }
-    th, td { border: 1px solid #999; padding: 3px 5px; text-align: left; vertical-align: top; }
-    th { background: #eee; font-weight: bold; }
-    tr:nth-child(even) td { background: #f7f7f7; }
+    th, td { border: 0.5px solid #bbb; padding: 2.5px 5px; vertical-align: top; }
+    thead th { background: #006FAD; color: #fff; font-weight: bold; text-align: left; font-size: 8pt; }
+    thead th.num { text-align: right; }
+    tbody tr:nth-child(even) td { background: #f4f8fb; }
+    td.num { text-align: right; white-space: nowrap; }
+    tr.totals td { border-top: 1.5px solid #006FAD; font-weight: bold; background: #eaf3fb; }
 </style>
-<h1>{{ title }}</h1>
+<div class="doc-head">
+    <h1>{{ title }}</h1>
+    <div class="sub">{% if subtitle %}{{ subtitle }}{% else %}Celkem {{ count }} záznamů{% endif %}</div>
+</div>
 <table>
     <thead>
     <tr>
-        {% for cell in header %}<th>{{ cell }}</th>{% endfor %}
+        {% for i, cell in header %}<th class="{{ align[i]|default('left') == 'right' ? 'num' : '' }}">{{ cell }}</th>{% endfor %}
     </tr>
     </thead>
     <tbody>
     {% for row in rows %}
         <tr>
-            {% for cell in row %}<td>{{ cell }}</td>{% endfor %}
+            {% for i, cell in row %}<td class="{{ align[i]|default('left') == 'right' ? 'num' : '' }}">{{ cell }}</td>{% endfor %}
         </tr>
     {% else %}
         <tr><td colspan="{{ header|length }}">Žádná data.</td></tr>
     {% endfor %}
+    {% if hasTotals %}
+        <tr class="totals">
+            {% for i in 0..(header|length - 1) %}<td class="{{ align[i]|default('left') == 'right' ? 'num' : '' }}">{{ i == 0 ? 'Celkem (' ~ count ~ ')' : totals[i]|default('') }}</td>{% endfor %}
+        </tr>
+    {% endif %}
     </tbody>
 </table>

--- a/Resources/views/web_admin/page-skeleton-web-admin.html.twig
+++ b/Resources/views/web_admin/page-skeleton-web-admin.html.twig
@@ -16,4 +16,16 @@
             </nav>
         {% endif %}
     {% endblock admin_breadcrumb %}
+    {# Flash zprávy (chyby/varování/úspěch). Web admin dosud žádné nerenderoval — bez tohoto
+       by upozornění z controllerů (např. odmítnutý příliš velký export) byla neviditelná. #}
+    {% block admin_flashes %}
+        {% for type, messages in app.flashes %}
+            {% set cssType = {'danger':'danger','error':'danger','warning':'warning','success':'success','notice':'info','info':'info'}[type]|default('info') %}
+            {% for message in messages %}
+                <div class="container" style="padding-top:.35rem;">
+                    <div class="alert alert-{{ cssType }}" role="alert" style="margin:.35rem 0;">{{ message }}</div>
+                </div>
+            {% endfor %}
+        {% endfor %}
+    {% endblock admin_flashes %}
 {% endblock body_header %}

--- a/Service/ExportService.php
+++ b/Service/ExportService.php
@@ -75,12 +75,29 @@ class ExportService
      */
     public function getPdfFromHtml(string $html, bool $landscape = false): string
     {
-        $mPdf = new Mpdf(['format' => 'A4'.($landscape ? '-L' : ''), 'mode' => 'utf-8']);
+        $app = $this->oswisCoreSettings->getApp();
+        $appName = is_string($app['name'] ?? null) ? $app['name'] : '';
+        $mPdf = new Mpdf([
+            'format'        => 'A4'.($landscape ? '-L' : ''),
+            'mode'          => 'utf-8',
+            'margin_top'    => 14,
+            'margin_bottom' => 14,
+            'margin_left'   => 10,
+            'margin_right'  => 10,
+            'margin_footer' => 6,
+        ]);
         $mPdf->setLogger($this->logger);
-        $mPdf->SetAuthor($this->oswisCoreSettings->getApp()['name']);
+        $mPdf->SetAuthor($appName);
         $mPdf->SetCreator($this->oswisCoreSettings->getCoreAppName());
         $mPdf->useSubstitutions = true;
         $mPdf->showImageErrors = true;
+        // Brandovaná patička: appka + datum generování vlevo, číslo stránky vpravo.
+        $mPdf->SetHTMLFooter(
+            '<table width="100%" style="font-family:sans-serif; font-size:7pt; color:#888; border-top:0.5px solid #ccc; padding-top:2px;"><tr>'
+            .'<td>'.htmlspecialchars($appName).' · vygenerováno '.date('j. n. Y H:i').'</td>'
+            .'<td align="right">strana {PAGENO} / {nbpg}</td>'
+            .'</tr></table>'
+        );
         $mPdf->WriteHTML($html);
         $output = $mPdf->Output('', 'S');
 

--- a/Service/ExportService.php
+++ b/Service/ExportService.php
@@ -71,12 +71,17 @@ class ExportService
     /**
      * Vyrenderuje libovolné HTML do PDF (string). Pro generický export framework.
      *
+     * @param string|null       $title    PDF metadata: titulek dokumentu (viewer / vyhledávání)
+     * @param string|null       $subject  PDF metadata: předmět (scope dokumentu)
+     * @param list<string>      $keywords PDF metadata: klíčová slova
+     *
      * @throws MpdfException
      */
-    public function getPdfFromHtml(string $html, bool $landscape = false): string
+    public function getPdfFromHtml(string $html, bool $landscape = false, ?string $title = null, ?string $subject = null, array $keywords = []): string
     {
         $app = $this->oswisCoreSettings->getApp();
         $appName = is_string($app['name'] ?? null) ? $app['name'] : '';
+        $creator = $this->oswisCoreSettings->getCoreAppName();
         $mPdf = new Mpdf([
             'format'        => 'A4'.($landscape ? '-L' : ''),
             'mode'          => 'utf-8',
@@ -87,8 +92,18 @@ class ExportService
             'margin_footer' => 6,
         ]);
         $mPdf->setLogger($this->logger);
+        // Plná sada PDF metadat (Producer/CreationDate/ModDate doplní mPDF automaticky).
         $mPdf->SetAuthor($appName);
-        $mPdf->SetCreator($this->oswisCoreSettings->getCoreAppName());
+        $mPdf->SetCreator($creator);
+        if (null !== $title && '' !== $title) {
+            $mPdf->SetTitle($title);
+        }
+        $mPdf->SetSubject($subject ?? ($title ?? ''));
+        $kw = array_values(array_filter([$appName, ...$keywords]));
+        if ([] !== $kw) {
+            $mPdf->SetKeywords(implode(', ', $kw));
+        }
+        $mPdf->SetDisplayMode('fullpage');
         $mPdf->useSubstitutions = true;
         $mPdf->showImageErrors = true;
         // Brandovaná patička: appka + datum generování vlevo, číslo stránky vpravo.

--- a/Service/ExportService.php
+++ b/Service/ExportService.php
@@ -25,8 +25,31 @@ class ExportService
     public function __construct(
         protected LoggerInterface $logger,
         protected Environment $templating,
-        protected OswisCoreSettingsProvider $oswisCoreSettings
+        protected OswisCoreSettingsProvider $oswisCoreSettings,
+        protected string $projectDir = ''
     ) {
+    }
+
+    /**
+     * Resolve the configured app logo (oswis.app.logo, a project-relative path) to an absolute
+     * filesystem path mPDF can embed. Tries the public web root first, then the project root.
+     * Returns '' when not configured or the file is missing (header then degrades to text only).
+     */
+    private function resolveLogoPath(): string
+    {
+        $app = $this->oswisCoreSettings->getApp();
+        $logoRel = is_string($app['logo'] ?? null) ? trim($app['logo']) : '';
+        if ('' === $logoRel || '' === $this->projectDir) {
+            return '';
+        }
+        foreach (['/public/', '/'] as $prefix) {
+            $candidate = $this->projectDir.$prefix.ltrim($logoRel, '/');
+            if (is_file($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return '';
     }
 
     /**
@@ -85,10 +108,11 @@ class ExportService
         $mPdf = new Mpdf([
             'format'        => 'A4'.($landscape ? '-L' : ''),
             'mode'          => 'utf-8',
-            'margin_top'    => 14,
+            'margin_top'    => 24, // room for the branded (logo) running header
             'margin_bottom' => 14,
             'margin_left'   => 10,
             'margin_right'  => 10,
+            'margin_header' => 8,
             'margin_footer' => 6,
         ]);
         $mPdf->setLogger($this->logger);
@@ -117,10 +141,19 @@ class ExportService
         if ((int) ini_get('pcre.recursion_limit') < $needed) {
             ini_set('pcre.recursion_limit', (string) $needed);
         }
-        // Brandovaná patička: appka + datum generování vlevo, číslo stránky vpravo.
+        // Brandovaná opakující se hlavička: logo vlevo, název appky vpravo (na každé stránce).
+        $logoPath = $this->resolveLogoPath();
+        $logoTag = '' !== $logoPath ? '<img src="'.htmlspecialchars($logoPath).'" height="30">' : '';
+        $mPdf->SetHTMLHeader(
+            '<table width="100%" style="border-bottom:0.5px solid #006FAD; padding-bottom:3px;"><tr>'
+            .'<td style="vertical-align:middle;">'.$logoTag.'</td>'
+            .'<td align="right" style="vertical-align:middle; font-family:sans-serif; font-size:8pt; color:#006FAD; font-weight:bold;">'.htmlspecialchars($appName).'</td>'
+            .'</tr></table>'
+        );
+        // Brandovaná patička: datum generování vlevo, číslo stránky vpravo.
         $mPdf->SetHTMLFooter(
             '<table width="100%" style="font-family:sans-serif; font-size:7pt; color:#888; border-top:0.5px solid #ccc; padding-top:2px;"><tr>'
-            .'<td>'.htmlspecialchars($appName).' · vygenerováno '.date('j. n. Y H:i').'</td>'
+            .'<td>vygenerováno '.date('j. n. Y H:i').'</td>'
             .'<td align="right">strana {PAGENO} / {nbpg}</td>'
             .'</tr></table>'
         );

--- a/Service/ExportService.php
+++ b/Service/ExportService.php
@@ -104,8 +104,19 @@ class ExportService
             $mPdf->SetKeywords(implode(', ', $kw));
         }
         $mPdf->SetDisplayMode('fullpage');
+        // Outline/záložky: H1 (titulek dokumentu) → záložka — navigace ve vícestránkových PDF.
+        $mPdf->h2bookmarks = ['H1' => 0];
         $mPdf->useSubstitutions = true;
         $mPdf->showImageErrors = true;
+        // Robustnost velkých exportů: u rozsáhlého HTML (stovky+ řádků) hrozí
+        // "HTML code size is larger than pcre.backtrack_limit" → navýšit limit dle délky HTML.
+        $needed = strlen($html) * 2 + 200000;
+        if ((int) ini_get('pcre.backtrack_limit') < $needed) {
+            ini_set('pcre.backtrack_limit', (string) $needed);
+        }
+        if ((int) ini_get('pcre.recursion_limit') < $needed) {
+            ini_set('pcre.recursion_limit', (string) $needed);
+        }
         // Brandovaná patička: appka + datum generování vlevo, číslo stránky vpravo.
         $mPdf->SetHTMLFooter(
             '<table width="100%" style="font-family:sans-serif; font-size:7pt; color:#888; border-top:0.5px solid #ccc; padding-top:2px;"><tr>'


### PR DESCRIPTION
Releases tagged **v0.2.15** (already pushed + deployed to prod). Brings master up to the released tag.

- Branded PDF export: logo running header, full metadata (Title/Subject/Keywords), H1 bookmarks, pcre.backtrack robustness for large HTML.
- Flash message rendering in the web_admin page skeleton.

PHPStan level max: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)