### PR TITLE
release: v0.2.17 — WebRedirect (spravované krátké odkazy)

### DIFF
--- a/Controller/Web/RedirectWebController.php
+++ b/Controller/Web/RedirectWebController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCoreBundle\Controller\Web;
+
+use Doctrine\ORM\EntityManagerInterface;
+use OswisOrg\OswisCoreBundle\Exceptions\NotFoundException;
+use OswisOrg\OswisCoreBundle\Repository\Web\WebRedirectRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Public endpoint of admin-managed short links ({@see \OswisOrg\OswisCoreBundle\Entity\Web\WebRedirect}):
+ * /redirect/{slug} and the QR-friendly alias /r/{slug}.
+ */
+class RedirectWebController extends AbstractController
+{
+    public function __construct(
+        private readonly WebRedirectRepository $redirectRepository,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * 302 (temporary — the target may be swapped in the admin at any time, and a reverse proxy or
+     * browser must not cache it permanently) with explicit no-store. Unknown or soft-deleted slug
+     * → standard 404 page.
+     *
+     * @throws NotFoundException
+     */
+    public function follow(string $slug): Response
+    {
+        $redirect = $this->redirectRepository->findOneActiveBySlug($slug);
+        if (null === $redirect || '' === $redirect->getTargetUrl()) {
+            throw new NotFoundException("(přesměrování: '$slug')");
+        }
+        $redirect->registerHit();
+        $this->em->flush();
+
+        $response = new RedirectResponse($redirect->getTargetUrl(), Response::HTTP_FOUND);
+        $response->headers->set('Cache-Control', 'no-store, private');
+
+        return $response;
+    }
+}

--- a/Controller/WebAdmin/WebAdminRedirectController.php
+++ b/Controller/WebAdmin/WebAdminRedirectController.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCoreBundle\Controller\WebAdmin;
+
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use OswisOrg\OswisCoreBundle\Entity\Web\WebRedirect;
+use OswisOrg\OswisCoreBundle\Form\WebAdmin\WebRedirectType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Web admin CRUD over {@see WebRedirect} short links (/web_admin/presmerovani).
+ * List + create + edit + soft-delete/restore; every mutation is POST + CSRF.
+ */
+#[IsGranted('ROLE_ADMIN')]
+class WebAdminRedirectController extends AbstractController
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+    }
+
+    public function index(): Response
+    {
+        $redirects = $this->em->getRepository(WebRedirect::class)->findBy([], ['slug' => 'ASC']);
+
+        return $this->render('@OswisOrgOswisCore/web_admin/redirects/index.html.twig', [
+            'redirects'  => $redirects,
+            'pageTitle'  => 'Přesměrování (krátké odkazy)',
+            'page_title' => 'Přesměrování :: ADMIN',
+        ]);
+    }
+
+    public function new(Request $request): Response
+    {
+        $redirect = new WebRedirect();
+        $form = $this->createForm(WebRedirectType::class, $redirect);
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->em->persist($redirect);
+            $this->em->flush();
+            $this->addFlash('success', sprintf('Přesměrování „%s" vytvořeno.', $redirect->getSlug()));
+
+            return new RedirectResponse($this->generateUrl('oswis_org_oswis_core_web_admin_redirects'));
+        }
+
+        return $this->render('@OswisOrgOswisCore/web_admin/redirects/edit.html.twig', [
+            'form'       => $form,
+            'entity'     => $redirect,
+            'pageTitle'  => 'Nové přesměrování',
+            'page_title' => 'Nové přesměrování :: ADMIN',
+        ]);
+    }
+
+    public function edit(Request $request, int $id): Response
+    {
+        $redirect = $this->em->find(WebRedirect::class, $id)
+            ?? throw $this->createNotFoundException('Přesměrování nenalezeno.');
+        $form = $this->createForm(WebRedirectType::class, $redirect);
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->em->flush();
+            $this->addFlash('success', sprintf('Přesměrování „%s" uloženo.', $redirect->getSlug()));
+
+            return new RedirectResponse($this->generateUrl('oswis_org_oswis_core_web_admin_redirects'));
+        }
+
+        return $this->render('@OswisOrgOswisCore/web_admin/redirects/edit.html.twig', [
+            'form'       => $form,
+            'entity'     => $redirect,
+            'pageTitle'  => sprintf('Přesměrování: %s', $redirect->getSlug()),
+            'page_title' => sprintf('Přesměrování: %s :: ADMIN', $redirect->getSlug()),
+        ]);
+    }
+
+    /** Soft-delete: the public route stops resolving the slug (404); the row stays restorable. */
+    public function delete(Request $request, int $id): Response
+    {
+        $redirect = $this->em->find(WebRedirect::class, $id)
+            ?? throw $this->createNotFoundException('Přesměrování nenalezeno.');
+        if (!$this->isCsrfTokenValid('web_redirect_delete_'.$id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $redirect->setDeletedAt(new DateTime());
+        $this->em->flush();
+        $this->addFlash('success', sprintf('Přesměrování „%s" deaktivováno (lze obnovit).', $redirect->getSlug()));
+
+        return new RedirectResponse($this->generateUrl('oswis_org_oswis_core_web_admin_redirects'));
+    }
+
+    public function restore(Request $request, int $id): Response
+    {
+        $redirect = $this->em->find(WebRedirect::class, $id)
+            ?? throw $this->createNotFoundException('Přesměrování nenalezeno.');
+        if (!$this->isCsrfTokenValid('web_redirect_restore_'.$id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $redirect->setDeletedAt(null);
+        $this->em->flush();
+        $this->addFlash('success', sprintf('Přesměrování „%s" obnoveno.', $redirect->getSlug()));
+
+        return new RedirectResponse($this->generateUrl('oswis_org_oswis_core_web_admin_redirects'));
+    }
+}

--- a/Entity/Web/WebRedirect.php
+++ b/Entity/Web/WebRedirect.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @noinspection MethodShouldBeFinalInspection
+ */
+
+namespace OswisOrg\OswisCoreBundle\Entity\Web;
+
+use DateTime;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\UniqueConstraint;
+use OswisOrg\OswisCoreBundle\Entity\NonPersistent\Nameable;
+use OswisOrg\OswisCoreBundle\Interfaces\Common\NameableInterface;
+use OswisOrg\OswisCoreBundle\Repository\Web\WebRedirectRepository;
+use OswisOrg\OswisCoreBundle\Traits\Common\DeletedTrait;
+use OswisOrg\OswisCoreBundle\Traits\Common\NameableTrait;
+
+/**
+ * Admin-managed short link: public /redirect/{slug} (alias /r/{slug}) 302-redirects to $targetUrl.
+ *
+ * Replaces yearly hardcoded redirect controller methods (feedback forms, FB events, QR posters):
+ * a new year/campaign is a DATA row added in the web admin, not a code change + deploy. The target
+ * may be swapped at any time (typo in a form link, moved event) without touching already-sent
+ * e-mails or printed QR codes. Soft-deleted/unknown slugs render the standard 404.
+ *
+ * Lives in CORE (not the optional web bundle) so that ANY bundle's content — calendar e-mail
+ * templates above all — may safely link the route in every deployment.
+ *
+ * Targets are entered exclusively by ROLE_ADMIN (curated list), so the public endpoint is not an
+ * open-redirect vector; the http(s)-only validation in the form is defense-in-depth.
+ */
+#[Entity(repositoryClass: WebRedirectRepository::class)]
+#[Table(name: 'core_web_redirect')]
+#[UniqueConstraint(name: 'UNIQ_CORE_WEB_REDIRECT_SLUG', columns: ['slug'])]
+class WebRedirect implements NameableInterface
+{
+    use NameableTrait;
+    use DeletedTrait;
+
+    /**
+     * Target the public route redirects to: absolute http(s) URL, or a site-relative path
+     * starting with a single "/" (internal pages; "//host" is rejected by the form as it would
+     * escape the site). Validation lives in {@see \OswisOrg\OswisCoreBundle\Form\WebAdmin\WebRedirectType}.
+     */
+    #[Column(type: 'string', length: 2048, nullable: false)]
+    protected string $targetUrl = '';
+
+    /** Lightweight usage counter (QR posters, campaigns); detailed logs live in the web server. */
+    #[Column(type: 'integer', nullable: false)]
+    protected int $hitCount = 0;
+
+    #[Column(type: 'datetime', nullable: true)]
+    protected ?DateTime $lastHitAt = null;
+
+    public function __construct(?Nameable $nameable = null, string $targetUrl = '')
+    {
+        $this->setFieldsFromNameable($nameable);
+        $this->setTargetUrl($targetUrl);
+    }
+
+    public function getTargetUrl(): string
+    {
+        return $this->targetUrl;
+    }
+
+    public function setTargetUrl(string $targetUrl): void
+    {
+        $this->targetUrl = trim($targetUrl);
+    }
+
+    public function getHitCount(): int
+    {
+        return $this->hitCount;
+    }
+
+    public function getLastHitAt(): ?DateTime
+    {
+        return $this->lastHitAt;
+    }
+
+    /** Record one public-route usage (caller flushes). */
+    public function registerHit(): void
+    {
+        ++$this->hitCount;
+        $this->lastHitAt = new DateTime();
+    }
+}

--- a/Form/WebAdmin/WebRedirectType.php
+++ b/Form/WebAdmin/WebRedirectType.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCoreBundle\Form\WebAdmin;
+
+use OswisOrg\OswisCoreBundle\Entity\Web\WebRedirect;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\AtLeastOneOf;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\Url;
+
+final class WebRedirectType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label'    => 'Název (interní popis)',
+                'required' => false,
+            ])
+            ->add('slug', TextType::class, [
+                'label'       => 'Slug (část URL)',
+                'required'    => true,
+                'help'        => 'Veřejná adresa bude /redirect/{slug} a /r/{slug}. Jen malá písmena, číslice a pomlčky.',
+                'attr'        => ['placeholder' => 'zpetna-vazba-seznamovak-up-2026-1-turnus', 'style' => 'font-family: monospace;'],
+                'constraints' => [
+                    new NotBlank(message: 'Slug je povinný.'),
+                    new Regex(pattern: '/^[a-z0-9-]+$/', message: 'Slug smí obsahovat jen malá písmena bez diakritiky, číslice a pomlčky.'),
+                    new Length(max: 170),
+                ],
+            ])
+            ->add('targetUrl', TextType::class, [
+                'label'       => 'Cílová adresa',
+                'required'    => true,
+                'help'        => 'Absolutní (https://…) nebo relativní v rámci webu (/akce/prihlaska/…).',
+                'attr'        => ['placeholder' => 'https://docs.google.com/forms/… nebo /akce/prihlaska/…'],
+                'constraints' => [
+                    new NotBlank(message: 'Cílová adresa je povinná.'),
+                    new Length(max: 2048),
+                    // Absolute http(s) URL OR a site-relative path. The path must start with a
+                    // single "/" — "//host" is protocol-relative (escapes the site) and is rejected.
+                    new AtLeastOneOf(
+                        constraints: [
+                            new Url(protocols: ['http', 'https'], requireTld: true),
+                            new Regex(pattern: '~^/(?!/)~'),
+                        ],
+                        message: 'Zadej absolutní http(s) adresu, nebo relativní cestu začínající "/".',
+                        includeInternalMessages: false,
+                    ),
+                ],
+            ])
+            ->add('note', TextType::class, [
+                'label'    => 'Poznámka',
+                'required' => false,
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'Uložit',
+                'attr'  => ['class' => 'btn btn-primary'],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(['data_class' => WebRedirect::class]);
+    }
+}

--- a/Repository/Web/WebRedirectRepository.php
+++ b/Repository/Web/WebRedirectRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCoreBundle\Repository\Web;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use OswisOrg\OswisCoreBundle\Entity\Web\WebRedirect;
+
+/**
+ * @extends ServiceEntityRepository<WebRedirect>
+ */
+class WebRedirectRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, WebRedirect::class);
+    }
+
+    /** Active (not soft-deleted) redirect for the public route; null renders 404. */
+    public function findOneActiveBySlug(string $slug): ?WebRedirect
+    {
+        $result = $this->createQueryBuilder('r')
+            ->where('r.slug = :slug')
+            ->andWhere('r.deletedAt IS NULL')
+            ->setParameter('slug', $slug)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $result instanceof WebRedirect ? $result : null;
+    }
+}

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -156,3 +156,41 @@ oswis_org_oswis_core_web_admin_logout:
 
 
 
+## Admin-managed short links (WebRedirect): public follow + QR-friendly alias.
+oswis_org_oswis_core_redirect:
+    controller: OswisOrg\OswisCoreBundle\Controller\Web\RedirectWebController::follow
+    path: "/redirect/{slug}"
+    methods: [GET]
+
+oswis_org_oswis_core_redirect_short:
+    controller: OswisOrg\OswisCoreBundle\Controller\Web\RedirectWebController::follow
+    path: "/r/{slug}"
+    methods: [GET]
+
+oswis_org_oswis_core_web_admin_redirects:
+    controller: OswisOrg\OswisCoreBundle\Controller\WebAdmin\WebAdminRedirectController::index
+    path: "/web_admin/presmerovani"
+    methods: [GET]
+
+oswis_org_oswis_core_web_admin_redirect_new:
+    controller: OswisOrg\OswisCoreBundle\Controller\WebAdmin\WebAdminRedirectController::new
+    path: "/web_admin/presmerovani/nove"
+    methods: [GET, POST]
+
+oswis_org_oswis_core_web_admin_redirect_edit:
+    controller: OswisOrg\OswisCoreBundle\Controller\WebAdmin\WebAdminRedirectController::edit
+    path: "/web_admin/presmerovani/{id}/upravit"
+    requirements: { id: '\d+' }
+    methods: [GET, POST]
+
+oswis_org_oswis_core_web_admin_redirect_delete:
+    controller: OswisOrg\OswisCoreBundle\Controller\WebAdmin\WebAdminRedirectController::delete
+    path: "/web_admin/presmerovani/{id}/smazat"
+    requirements: { id: '\d+' }
+    methods: [POST]
+
+oswis_org_oswis_core_web_admin_redirect_restore:
+    controller: OswisOrg\OswisCoreBundle\Controller\WebAdmin\WebAdminRedirectController::restore
+    path: "/web_admin/presmerovani/{id}/obnovit"
+    requirements: { id: '\d+' }
+    methods: [POST]

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -607,3 +607,21 @@ services:
         arguments: [ '@OswisOrg\OswisCoreBundle\OpenApi\OpenApiFactory.inner' ]
         autoconfigure: false
         decoration_priority: 1000
+
+    ## Admin-managed short links (WebRedirect): public follow controller + admin CRUD + repository.
+    OswisOrg\OswisCoreBundle\Controller\Web\RedirectWebController:
+        autowire: true
+        autoconfigure: true
+        public: true
+        tags: [ 'controller.service_arguments' ]
+
+    OswisOrg\OswisCoreBundle\Controller\WebAdmin\WebAdminRedirectController:
+        autowire: true
+        autoconfigure: true
+        public: true
+        tags: [ 'controller.service_arguments' ]
+
+    OswisOrg\OswisCoreBundle\Repository\Web\WebRedirectRepository:
+        autowire: true
+        autoconfigure: true
+        tags: [ 'doctrine.repository_service' ]

--- a/Resources/views/web_admin/redirects/edit.html.twig
+++ b/Resources/views/web_admin/redirects/edit.html.twig
@@ -1,0 +1,27 @@
+{% extends '@OswisOrgOswisCore/web_admin/page-skeleton-web-admin.html.twig' %}
+
+{% block html_title %}{{ page_title }}{% endblock %}
+
+{% block body_content %}
+    <main class="container">
+        <h2>{{ pageTitle }}</h2>
+        <p>
+            <a class="btn btn-sm btn-link"
+               href="{{ path('oswis_org_oswis_core_web_admin_redirects') }}">← Zpět na přesměrování</a>
+        </p>
+        {{ form_start(form, { attr: { novalidate: 'novalidate' } }) }}
+        {{ form_widget(form) }}
+        {{ form_end(form, { render_rest: false }) }}
+
+        {% if entity.id and entity.slug %}
+            <p style="margin-top: .75rem;">
+                Veřejné adresy:
+                <a href="{{ path('oswis_org_oswis_core_redirect', { slug: entity.slug }) }}" target="_blank" rel="noopener">
+                    <code>{{ url('oswis_org_oswis_core_redirect', { slug: entity.slug }) }}</code></a>
+                ·
+                <a href="{{ path('oswis_org_oswis_core_redirect_short', { slug: entity.slug }) }}" target="_blank" rel="noopener">
+                    <code>{{ url('oswis_org_oswis_core_redirect_short', { slug: entity.slug }) }}</code></a>
+            </p>
+        {% endif %}
+    </main>
+{% endblock %}

--- a/Resources/views/web_admin/redirects/index.html.twig
+++ b/Resources/views/web_admin/redirects/index.html.twig
@@ -1,0 +1,66 @@
+{% extends '@OswisOrgOswisCore/web_admin/page-skeleton-web-admin.html.twig' %}
+
+{% block html_title %}{{ page_title }}{% endblock %}
+
+{% block body_content %}
+    <main class="container">
+        <h2>{{ pageTitle }}</h2>
+        <p>
+            Krátké odkazy <code>/redirect/{slug}</code> (alias <code>/r/{slug}</code>) — zpětné vazby,
+            FB eventy, QR kódy… Cíl lze kdykoli změnit bez zásahu do rozeslaných e-mailů či tisků.
+        </p>
+        <p>
+            <a class="btn btn-sm btn-primary" href="{{ path('oswis_org_oswis_core_web_admin_redirect_new') }}">+ Nové přesměrování</a>
+        </p>
+        <table class="list" style="width: 100%;">
+            <thead>
+                <tr>
+                    <th style="width: 3rem;">ID</th>
+                    <th>Slug</th>
+                    <th>Název</th>
+                    <th>Cíl</th>
+                    <th style="width: 5rem; text-align: right;" title="Počet použití">Hitů</th>
+                    <th style="width: 9rem;" title="Poslední použití">Naposledy</th>
+                    <th style="width: 11rem;"></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for r in redirects %}
+                    <tr{% if r.deletedAt %} style="opacity: .55;"{% endif %}>
+                        <td>{{ r.id }}</td>
+                        <td>
+                            <code>{{ r.slug }}</code>
+                            {% if r.deletedAt %}<small style="color: #b02a37;"> (deaktivováno)</small>{% endif %}
+                        </td>
+                        <td>{{ r.name|default('—') }}</td>
+                        <td style="max-width: 28rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                            <a href="{{ r.targetUrl }}" target="_blank" rel="noopener" title="{{ r.targetUrl }}">{{ r.targetUrl }}</a>
+                        </td>
+                        <td style="text-align: right;">{{ r.hitCount }}</td>
+                        <td>{{ r.lastHitAt ? r.lastHitAt|date('j. n. Y H:i') : '—' }}</td>
+                        <td>
+                            <a class="btn btn-sm btn-outline-primary"
+                               href="{{ path('oswis_org_oswis_core_web_admin_redirect_edit', { id: r.id }) }}">✎ Upravit</a>
+                            {% if r.deletedAt %}
+                                <form method="post" style="display: inline;"
+                                      action="{{ path('oswis_org_oswis_core_web_admin_redirect_restore', { id: r.id }) }}">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('web_redirect_restore_' ~ r.id) }}">
+                                    <button class="btn btn-sm btn-outline-success" type="submit">↻ Obnovit</button>
+                                </form>
+                            {% else %}
+                                <form method="post" style="display: inline;"
+                                      action="{{ path('oswis_org_oswis_core_web_admin_redirect_delete', { id: r.id }) }}"
+                                      onsubmit="return confirm('Deaktivovat přesměrování „{{ r.slug }}“? Veřejná adresa přestane fungovat (lze obnovit).');">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('web_redirect_delete_' ~ r.id) }}">
+                                    <button class="btn btn-sm btn-outline-danger" type="submit">🗑 Deaktivovat</button>
+                                </form>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% else %}
+                    <tr><td colspan="7" style="text-align: center; color: #6c757d;">Zatím žádná přesměrování.</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </main>
+{% endblock %}

--- a/Resources/views/web_admin/web-admin-homepage.html.twig
+++ b/Resources/views/web_admin/web-admin-homepage.html.twig
@@ -60,6 +60,9 @@
                         <li>
                             <a href="{{ path('oswis_org_oswis_core_internal_action_clear_cache') }}">Smazat cache</a>
                         </li>
+                        <li>
+                            <a href="{{ path('oswis_org_oswis_core_web_admin_redirects') }}">Přesměrování (krátké odkazy)</a>
+                        </li>
                     </ul>
 
                     <h2>Účastníci a přihlášky</h2>


### PR DESCRIPTION
## Co přidává

**WebRedirect** — admin-spravované přesměrovací odkazy. Veřejné routy `/redirect/{slug}` + alias `/r/{slug}` → 302 na cílovou adresu (absolutní http(s) i site-relativní), `Cache-Control: no-store`. Neznámý/deaktivovaný slug → 404.

- Entita `Entity/Web/WebRedirect` (tabulka `core_web_redirect`, NameableTrait + DeletedTrait, hitCount + lastHitAt)
- Admin CRUD `/web_admin/presmerovani` (ROLE_ADMIN, mutace POST+CSRF, soft-delete/restore)
- Odkaz na admin hubu (Systémové akce)

Nahrazuje roční hardcoded redirect routy (feedback formuláře, FB eventy, QR) — nový ročník = datový řádek, ne deploy. Návrh: `docs/OSWIS_1_WEB_REDIRECTS_DESIGN_2026-06-11.md` (workspace).

## Verifikace
PHPStan max 0 (core+app) · schema:validate green · twig/yaml lint · funkční smoke 8/8 (89 assertů, vč. nového testWebRedirects) · proklik na klonu (create→302→hitCount→deaktivace→404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)