### PR TITLE
fix(web-admin): N-level breadcrumb (crumbs[] + html_title fallback)

### DIFF
--- a/Resources/views/web_admin/page-skeleton-web-admin.html.twig
+++ b/Resources/views/web_admin/page-skeleton-web-admin.html.twig
@@ -2,16 +2,27 @@
 
 {% block body_header %}
     {% include '@OswisOrgOswisCore/web_admin/header.html.twig' %}
-    {# Drobečková navigace: vždy odkaz na Úvod (admin hub) + titulek aktuální stránky.
-       Odvozeno z existující proměnné `title` (oříznut suffix " :: ADMIN"), žádná nová
-       redundantní proměnná. Stránky můžou blok přepsat bohatší cestou. #}
+    {# Drobečková navigace: „Úvod" je vždy první, pak cesta libovolné hloubky.
+       Stránka může předat `crumbs` = [{label, url?}, …] (poslední = aktuální stránka, bez odkazu).
+       Bez `crumbs` se odvodí jednoúrovňová cesta z titulku stránky (block `html_title`,
+       oříznut suffix " :: …"), takže drobeček funguje i bez explicitní konfigurace. #}
     {% block admin_breadcrumb %}
-        {% set crumbTitle = (title|default(''))|split(' :: ')|first|split(' · ')|first|trim %}
         {% if app.request.attributes.get('_route') != 'oswis_org_oswis_core_web_admin_homepage' %}
+            {% set crumbList = crumbs|default([]) %}
+            {% if crumbList is empty %}
+                {% set crumbTitle = block('html_title')|split(' :: ')|first|split(' · ')|first|trim %}
+                {% if crumbTitle %}{% set crumbList = [{ 'label': crumbTitle }] %}{% endif %}
+            {% endif %}
             <nav aria-label="breadcrumb" class="container" style="padding-top:.25rem;">
                 <ol class="breadcrumb" style="margin:.35rem 0; font-size:.9rem;">
                     <li class="breadcrumb-item"><a href="{{ path('oswis_org_oswis_core_web_admin_homepage') }}">Úvod</a></li>
-                    {% if crumbTitle %}<li class="breadcrumb-item active" aria-current="page">{{ crumbTitle }}</li>{% endif %}
+                    {% for crumb in crumbList %}
+                        {% if crumb.url is defined and crumb.url and not loop.last %}
+                            <li class="breadcrumb-item"><a href="{{ crumb.url }}">{{ crumb.label }}</a></li>
+                        {% else %}
+                            <li class="breadcrumb-item active" aria-current="page">{{ crumb.label }}</li>
+                        {% endif %}
+                    {% endfor %}
                 </ol>
             </nav>
         {% endif %}


### PR DESCRIPTION
Drobečková navigace v `page-skeleton-web-admin` umí libovolný počet úrovní z pole `crumbs` (každá `{label, url?}`, poslední = aktuální bez odkazu); bez `crumbs` se odvodí jednoúrovňová cesta z `block('html_title')`. Opravuje dřívější 2-úrovňové omezení a prázdný `title`.

lint:twig OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)